### PR TITLE
Combine OptionalResult and OptionalInput types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 install:
   - . $HOME/.nvm/nvm.sh
   - nvm install stable
-  - npm install -g apollo@2.3.0
+  - npm install -g apollo@2.4.4
 script:
   - sbt tests/test
   - sbt ";set scalaJSStage in Global := FullOptStage; tests/test"

--- a/core/src/main/scala/com/apollographql/scalajs/OptionalResult.scala
+++ b/core/src/main/scala/com/apollographql/scalajs/OptionalResult.scala
@@ -3,14 +3,14 @@ package com.apollographql.scalajs
 import scala.scalajs.js
 import scala.language.implicitConversions
 
-@js.native trait OptionalInput[T] extends js.Object
-object OptionalInput {
-  final def empty[T]: OptionalInput[T] = null.asInstanceOf[OptionalInput[T]]
-  implicit def fromValue[T](v: T): OptionalInput[T] = v.asInstanceOf[OptionalInput[T]]
-  implicit def fromOption[T](v: Option[T])(implicit ev: Null <:< T): OptionalInput[T] = v.orNull.asInstanceOf[OptionalInput[T]]
-}
+@js.native trait OptionalValue[T] extends js.Object
+object OptionalValue {
+  implicit class OptionalValueExt[T](private val optionalValue: OptionalValue[T]) extends AnyVal {
+    def toOption: Option[T] = Option(optionalValue.asInstanceOf[T])
+  }
 
-@js.native trait OptionalResult[T] extends js.Object
-object OptionalResult {
-  implicit def toOption[T](orig: OptionalResult[T]): Option[T] = Option(orig.asInstanceOf[T])
+  final def empty[T]: OptionalValue[T] = null.asInstanceOf[OptionalValue[T]]
+  implicit def toOption[T](v: OptionalValue[T]): Option[T] = v.toOption
+  implicit def fromValue[T](v: T): OptionalValue[T] = v.asInstanceOf[OptionalValue[T]]
+  implicit def fromOption[T](v: Option[T])(implicit ev: Null <:< T): OptionalValue[T] = v.orNull.asInstanceOf[OptionalValue[T]]
 }

--- a/react/src/main/scala/com/apollographql/scalajs/react/Mutation.scala
+++ b/react/src/main/scala/com/apollographql/scalajs/react/Mutation.scala
@@ -10,7 +10,7 @@ import scala.language.implicitConversions
 import scala.scalajs.js
 import scala.scalajs.js.|
 
-case class MutationData[T](loading: Boolean, called: Boolean, error: Option[Error], data: Option[T])
+case class MutationData[T](loading: Boolean, called: Boolean, error: Option[js.Error], data: Option[T])
 object MutationData {
   implicit def reader[T](implicit tReader: Reader[T]): Reader[MutationData[T]] = { o =>
     val dyn = o.asInstanceOf[js.Dynamic]
@@ -18,7 +18,7 @@ object MutationData {
     MutationData(
       loading,
       Reader.booleanReader.read(dyn.called.asInstanceOf[js.Object]),
-      Reader.optionReader[Error].read(dyn.error.asInstanceOf[js.Object]),
+      Reader.optionReader[js.Error].read(dyn.error.asInstanceOf[js.Object]),
       if (loading) None else Reader.optionReader(tReader).read(dyn.data.asInstanceOf[js.Object])
     )
   }


### PR DESCRIPTION
Since the underlying representation is the same anyway, it doesn't make too much sense to have different types anymore.