### PR TITLE
Added refetchQueries prop to mutation

### DIFF
--- a/tests/src/test/graphql/mutations/todos.graphql
+++ b/tests/src/test/graphql/mutations/todos.graphql
@@ -1,0 +1,5 @@
+query AllTodosId {
+    todos {
+        id
+    }
+}


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [X] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

### Summary of the changes
I've added to the Mutation object the prop `refetchQueries`, this is useful in cases where, after a certain change, one or more queries need to be refetched. As this is not the only way to update the cache (i.e. `update` is the fine grain way), I've put this into a data object named `UpdateStrategy` so that in future if me or someone else wants to add `update` or change `refetchQueries` he can do it without compromising existing code as long as he provides defaults for the case class properties.

I have deleted the version of the method `apply` with a single generic type `T` because it was the same as the one with `T` and `V` fixing `V =:= Unit`.
I overloaded the remaining `apply` methods so that I am not breaking any existing code. I tried to create a version with default parameters instead of overloading but the compiler didn't like it.

I haven't written any test because I could not run the tests locally. I've tried running tests/test after having installed apollo but it doesn't work, I get an error. I've tested the change manually in the project I'm working on but there is no automated test. If you provide the instructions to run the tests from sbt I'm happy to write a couple. 
