### PR TITLE
Upgrade docs theme to 0.2.41

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6053,9 +6053,9 @@
       }
     },
     "gatsby-theme-apollo": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-apollo/-/gatsby-theme-apollo-0.1.10.tgz",
-      "integrity": "sha512-fMPPa+2HEh2ADEpbnMozNZbWSZEVppFTIXpG20pTHzUMPmgMyOeZjQ1jeVSfLozIYg+L+iKbskg3RBbBUVgIlQ==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-apollo/-/gatsby-theme-apollo-0.1.11.tgz",
+      "integrity": "sha512-4c+ofzunYWiKBP+muKqYG3GT9bkiVN9Ch18RTa8we3eeorofJQDUTGmFy9Z6XEPyGv0XfsaGwJhVYIqvv7gagQ==",
       "requires": {
         "@emotion/core": "^10.0.7",
         "@emotion/styled": "^10.0.7",
@@ -6077,15 +6077,15 @@
       }
     },
     "gatsby-theme-apollo-docs": {
-      "version": "0.2.40",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-apollo-docs/-/gatsby-theme-apollo-docs-0.2.40.tgz",
-      "integrity": "sha512-mjwxveRCrMsVhmmpZd2YZW89CVAWnWgqwfcQp7LOYDybDV/BcmFG3U8FxtzC/heaGVQZ68u/JtmY5h26DxLwsQ==",
+      "version": "0.2.41",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-apollo-docs/-/gatsby-theme-apollo-docs-0.2.41.tgz",
+      "integrity": "sha512-Ql2WjNYtScjQmhjt4Rdu1wULnlAjUDZNowUkFxnNmlES65TIXmmhbdtH899WQTAH1PgozQ6yXFji18hZZEJgCA==",
       "requires": {
         "detab": "^2.0.1",
         "gatsby": "^2.2.6",
         "gatsby-plugin-google-analytics": "^2.0.17",
         "gatsby-plugin-less": "^2.0.12",
-        "gatsby-theme-apollo": "^0.1.10",
+        "gatsby-theme-apollo": "^0.1.11",
         "gray-matter": "^4.0.1",
         "handlebars": "^4.1.0",
         "hast-util-is-element": "^1.0.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,6 @@
   },
   "dependencies": {
     "gatsby": "^2.2.6",
-    "gatsby-theme-apollo-docs": "^0.2.40"
+    "gatsby-theme-apollo-docs": "^0.2.41"
   }
 }


### PR DESCRIPTION
This branch upgrades the docs theme, fixing two issues in Safari and making active sidebar categories collapsible.