### PR TITLE
Added request and onError to ApolloBoostClientOptions

### DIFF
--- a/core/src/main/scala/com/apollographql/scalajs/ApolloBoost.scala
+++ b/core/src/main/scala/com/apollographql/scalajs/ApolloBoost.scala
@@ -1,12 +1,31 @@
 package com.apollographql.scalajs
 
+import com.apollographql.scalajs.link.Operation
 import slinky.readwrite.ObjectOrWritten
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 
 case class ApolloBoostClientOptions(uri: String,
-                                    fetchOptions: js.UndefOr[js.Object] = js.undefined)
+                                    fetchOptions: js.UndefOr[js.Object] = js.undefined,
+                                    request: js.UndefOr[js.Function1[Operation, js.Promise[js.Any]]] = js.undefined,
+                                    onError: js.UndefOr[js.Function1[ApolloError, js.Any]] = js.undefined)
+
+@js.native
+trait ApolloError extends js.Object {
+  val operation: js.Object = js.native
+  val response: js.Object = js.native
+  val graphQLErrors: js.Object = js.native
+  val networkError: ApolloNetworkError = js.native
+}
+
+@js.native
+trait ApolloNetworkError extends js.Object {
+  val name: String = js.native
+  val response: js.Object = js.native
+  val statusCode: Int = js.native
+  val bodyText: String = js.native
+}
 
 @JSImport("apollo-boost", JSImport.Default)
 @js.native


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [X] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

In this PR I've added two configs to the ApolloBoostClient. I've also added some object mappings to make the navigation of the objects better.
These configurations are taken straight from the ApolloClient documentation.