### PR TITLE
Prep for Archival

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,3 +6,12 @@
             "5926b555e4866ebe8daf80408adbd5743ef2a2ab",
             
         ]
+
+[[ rules ]]
+    id = "generic-api-key"
+    [ rules.allowlist ]
+        commits = [
+            # The same secret as was showing up above appeared in a differnet signature
+            # This is a defunct API key for algolia docsearch
+            "5926b555e4866ebe8daf80408adbd5743ef2a2ab"
+        ]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Archival
+This repo was archived by the Apollo Security team on 2023-05-26
+
+
 # Apollo Scala.js
 _use Apollo Client and React Apollo from your Scala.js apps!_
 


### PR DESCRIPTION
This PR preps the repo for archival. It makes 2 changes if needed:
1. Updates readme with a note about archival
2. Defangs any CI config. This is done so that if the repo is ever restored, there are no surprise CI runs. To revert this change, rename the CI configuration folder back to its required name (`_github` -> `.github` OR `_circleci` -> `.circleci`) as appropriate.